### PR TITLE
Add alerts when users visit reservation-summary endpoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
 	"cSpell.words": [
 		"CSRF",
 		"Swal",
+		"asaskevich",
 		"govalidator",
 		"justinas",
 		"nosurf",

--- a/internal/forms/forms.go
+++ b/internal/forms/forms.go
@@ -12,8 +12,8 @@ import (
 
 // Form creates a custom form struct, embeds a url.Values object
 type Form struct {
-	url.Values
-	Errors errors
+	url.Values // `Values` is typically used for query parameters and form values
+	Errors     errors
 }
 
 // New initializes a form struct

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -153,8 +153,12 @@ func (m *Repository) ReservationSummary(w http.ResponseWriter, r *http.Request) 
 	reservation, ok := m.App.Session.Get(r.Context(), "reservation").(models.Reservation)
 	if !ok {
 		log.Println("cannot get item from session")
+		m.App.Session.Put(r.Context(), "error", "Can't get reservation from session")
+		http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 		return
 	}
+
+	m.App.Session.Remove(r.Context(), "reservation")
 
 	data := make(map[string]interface{})
 	data["reservation"] = reservation

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -22,6 +22,9 @@ func NewTemplate(a *config.AppConfig) {
 }
 
 func AddDefaultData(td *models.TemplateData, r *http.Request) *models.TemplateData {
+	td.Flash = app.Session.PopString(r.Context(), "flash")
+	td.Error = app.Session.PopString(r.Context(), "error")
+	td.Warning = app.Session.PopString(r.Context(), "warning")
 	td.CSRFToken = nosurf.Token(r)
 	return td
 }

--- a/templates/base.layout.tmpl
+++ b/templates/base.layout.tmpl
@@ -166,6 +166,18 @@
         });
       }
 
+      {{ with .Error }}
+        notify("{{ . }}", "error");
+      {{ end }}
+
+      {{ with .Flash }}
+        notify("{{ . }}", "success");
+      {{ end }}
+
+      {{ with .Warning }}
+        notify("{{ . }}", "warning");
+      {{ end }}
+
       function Prompt() {
         let toast = function (c) {
           const { msg = "", icon = "success", position = "top-end" } = c;


### PR DESCRIPTION
# Why

Force user to fill the form

# What

- Show alerts if users visit `reservation-summary` endpoint directly
